### PR TITLE
build(deps): Migrating from gtk3 & webkit2gtk to gtk4 & webkitgtk-6.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,9 @@
 project(
-  'sea-greeter', 'c',
+  'sea-greeter',
+  'c',
   version: '0.1',
   license: 'GPL-3.0-or-later',
-  default_options: ['warning_level=3']
+  default_options: ['warning_level=3'],
 )
 
 as_version = meson.project_version()

--- a/src/bridge/bridge-object.c
+++ b/src/bridge/bridge-object.c
@@ -1,5 +1,5 @@
 #include <jsc/jsc.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "bridge/bridge-object.h"
 #include "bridge/utils.h"

--- a/src/bridge/bridge-object.h
+++ b/src/bridge/bridge-object.h
@@ -2,7 +2,7 @@
 #define BRIDGE_OBJECT_H 1
 
 #include <jsc/jsc.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "bridge/utils.h"
 #include "browser-web-view.h"

--- a/src/bridge/greeter_comm.c
+++ b/src/bridge/greeter_comm.c
@@ -1,18 +1,13 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <jsc/jsc.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "bridge/bridge-object.h"
-#include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
 #include "browser-web-view.h"
 
 #include "browser.h"
-#include "logger.h"
 #include "utils/utils.h"
 
 extern GPtrArray *greeter_browsers;
@@ -54,7 +49,7 @@ GreeterComm_window_metadata_cb(GPtrArray *arguments, BrowserWebView *web_view)
 
   JSCValue *value = jsc_value_new_object(context, NULL, NULL);
   jsc_value_object_set_property(value, "id", jsc_value_new_number(context, meta.id));
-  jsc_value_object_set_property(value, "is_primary", jsc_value_new_boolean(context, meta.is_primary));
+  jsc_value_object_set_property(value, "is_primary", jsc_value_new_boolean(context, meta.is_valid));
 
   JSCValue *position = jsc_value_new_object(context, NULL, NULL);
   jsc_value_object_set_property(position, "x", jsc_value_new_number(context, meta.geometry.x));

--- a/src/bridge/greeter_comm.h
+++ b/src/bridge/greeter_comm.h
@@ -3,7 +3,7 @@
 
 #include "browser-web-view.h"
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 void GreeterComm_initialize(void);
 void GreeterComm_destroy(void);

--- a/src/bridge/greeter_config.c
+++ b/src/bridge/greeter_config.c
@@ -1,19 +1,14 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <jsc/jsc.h>
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "bridge/bridge-object.h"
 #include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
 
-#include "logger.h"
 #include "settings.h"
-#include "utils/utils.h"
 
 static BridgeObject *GreeterConfig_object = NULL;
 

--- a/src/bridge/greeter_config.h
+++ b/src/bridge/greeter_config.h
@@ -3,7 +3,7 @@
 
 #include "browser-web-view.h"
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 void GreeterConfig_destroy(void);
 void GreeterConfig_initialize(void);

--- a/src/bridge/lightdm-objects.c
+++ b/src/bridge/lightdm-objects.c
@@ -1,7 +1,4 @@
 #include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <jsc/jsc.h>

--- a/src/bridge/lightdm.c
+++ b/src/bridge/lightdm.c
@@ -1,11 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
 #include <jsc/jsc.h>
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "bridge/bridge-object.h"
 #include "bridge/lightdm-objects.h"
@@ -14,7 +12,6 @@
 #include "browser.h"
 #include "lightdm/language.h"
 #include "logger.h"
-#include "settings.h"
 #include "utils/utils.h"
 
 static LightDMGreeter *Greeter;

--- a/src/bridge/lightdm.h
+++ b/src/bridge/lightdm.h
@@ -3,7 +3,7 @@
 
 #include "browser-web-view.h"
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 void LightDM_initialize(void);
 void LightDM_destroy(void);

--- a/src/bridge/theme_utils.c
+++ b/src/bridge/theme_utils.c
@@ -5,15 +5,13 @@
 #include <unistd.h>
 
 #include <jsc/jsc.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "bridge/bridge-object.h"
-#include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
 
 #include "logger.h"
 #include "settings.h"
-#include "utils/utils.h"
 
 static GPtrArray *allowed_dirs = NULL;
 extern GString *shared_data_directory;

--- a/src/bridge/theme_utils.h
+++ b/src/bridge/theme_utils.h
@@ -3,7 +3,7 @@
 
 #include "browser-web-view.h"
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 void ThemeUtils_initialize(void);
 void ThemeUtils_destroy(void);

--- a/src/bridge/utils.c
+++ b/src/bridge/utils.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/src/browser-web-view.h
+++ b/src/browser-web-view.h
@@ -2,7 +2,7 @@
 #define BROWSER_WEB_VIEW_H 1
 
 #include <gtk/gtk.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 G_BEGIN_DECLS
 

--- a/src/browser.h
+++ b/src/browser.h
@@ -14,7 +14,7 @@ typedef struct {
 
 typedef struct {
   guint64 id;
-  gboolean is_primary;
+  gboolean is_valid;
   GdkRectangle geometry;
   OverallBoundary overall_boundary;
 } WindowMetadata;
@@ -30,13 +30,13 @@ struct _Browser {
   BrowserWebView *web_view;
   GdkMonitor *monitor;
   gboolean debug_mode;
-  gboolean is_primary;
+  gboolean is_valid;
   WindowMetadata meta;
 };
 
 void browser_set_overall_boundary(GPtrArray *browsers);
 Browser *browser_new(GtkApplication *app, GdkMonitor *monitor);
-Browser *browser_new_full(GtkApplication *app, GdkMonitor *monitor, gboolean debug_mode, gboolean is_primary);
+Browser *browser_new_full(GtkApplication *app, GdkMonitor *monitor, gboolean debug_mode, gboolean is_valid);
 void browser_show_menu_bar(Browser *browser, gboolean show);
 
 G_END_DECLS

--- a/src/extension/greeter_comm.c
+++ b/src/extension/greeter_comm.c
@@ -1,12 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
-#include "extension/lightdm-signal.h"
+#include "bridge/utils.h"
 #include "utils/ipc-renderer.h"
 #include "utils/utils.h"
 
@@ -201,7 +198,7 @@ GreeterComm_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension)
+    WebKitWebProcessExtension *extension)
 {
   (void) extension;
 

--- a/src/extension/greeter_comm.h
+++ b/src/extension/greeter_comm.h
@@ -2,12 +2,12 @@
 #define EXTENSION_GREETER_COMM_H 1
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 void GreeterComm_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension);
+    WebKitWebProcessExtension *extension);
 
 #endif

--- a/src/extension/greeter_config.c
+++ b/src/extension/greeter_config.c
@@ -1,18 +1,12 @@
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
-
-#include "logger.h"
-#include "settings.h"
+#include <webkit/webkit-web-process-extension.h>
 
 #include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
 
-#include "extension/lightdm-signal.h"
 #include "utils/ipc-renderer.h"
 #include "utils/utils.h"
 
@@ -88,7 +82,7 @@ GreeterConfig_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension)
+    WebKitWebProcessExtension *extension)
 {
   (void) extension;
   WebPage = web_page;

--- a/src/extension/greeter_config.h
+++ b/src/extension/greeter_config.h
@@ -2,12 +2,12 @@
 #define EXTENSION_GREETER_CONFIG_H 1
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 void GreeterConfig_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension);
+    WebKitWebProcessExtension *extension);
 
 #endif

--- a/src/extension/lightdm-signal.c
+++ b/src/extension/lightdm-signal.c
@@ -1,10 +1,8 @@
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <jsc/jsc.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 #include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
@@ -138,7 +136,7 @@ LightDM_signal_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension)
+    WebKitWebProcessExtension *extension)
 {
   (void) web_page;
   (void) extension;

--- a/src/extension/lightdm-signal.h
+++ b/src/extension/lightdm-signal.h
@@ -2,7 +2,7 @@
 #define EXTENSION_LIGHTDM_SIGNAL 1
 
 #include <glib-object.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 #include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
@@ -15,7 +15,7 @@ void LightDM_signal_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension);
+    WebKitWebProcessExtension *extension);
 void initialize_object_signals(JSCContext *js_context, JSCValue *object, const struct JSCClassSignal signals[]);
 
 #endif

--- a/src/extension/lightdm.c
+++ b/src/extension/lightdm.c
@@ -1,20 +1,13 @@
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
-
-#include "logger.h"
-#include "settings.h"
+#include <webkit/webkit-web-process-extension.h>
 
 #include "extension/lightdm-signal.h"
 #include "utils/ipc-renderer.h"
 #include "utils/utils.h"
 
-/*extern WebKitWebExtension *WebExtension;*/
-/*extern guint64 page_id;*/
 static WebKitWebPage *WebPage;
 
 static JSCClass *LightDM_class;
@@ -721,7 +714,7 @@ LightDM_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension)
+    WebKitWebProcessExtension *extension)
 {
   (void) extension;
 

--- a/src/extension/lightdm.h
+++ b/src/extension/lightdm.h
@@ -2,12 +2,12 @@
 #define EXTENSION_LIGHTDM_H 1
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 void LightDM_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension);
+    WebKitWebProcessExtension *extension);
 
 #endif

--- a/src/extension/theme_utils.c
+++ b/src/extension/theme_utils.c
@@ -1,15 +1,11 @@
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 #include "bridge/lightdm-objects.h"
 #include "bridge/utils.h"
-
-#include "logger.h"
 
 #include "utils/ipc-renderer.h"
 #include "utils/utils.h"
@@ -167,7 +163,7 @@ ThemeUtils_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension)
+    WebKitWebProcessExtension *extension)
 {
   WebPage = web_page;
   (void) extension;

--- a/src/extension/theme_utils.h
+++ b/src/extension/theme_utils.h
@@ -2,12 +2,12 @@
 #define BRIDGE_THEME_UTILS_H 1
 
 #include <lightdm-gobject-1/lightdm.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 void ThemeUtils_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension);
+    WebKitWebProcessExtension *extension);
 
 #endif

--- a/src/extensions.c
+++ b/src/extensions.c
@@ -1,9 +1,7 @@
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 #include "lightdm-extension.h"
-#include "logger.h"
 
-#include "extension/greeter_config.h"
 #include "utils/ipc-renderer.h"
 
 gboolean stop_prompts = false;
@@ -102,7 +100,7 @@ web_page_console_message_sent(WebKitWebPage *web_page, WebKitConsoleMessage *con
 }
 
 static void
-web_page_created_callback(WebKitWebExtension *extension, WebKitWebPage *web_page, gpointer user_data)
+web_page_created_callback(WebKitWebProcessExtension *extension, WebKitWebPage *web_page, gpointer user_data)
 {
   (void) extension;
 
@@ -123,10 +121,9 @@ web_page_created_callback(WebKitWebExtension *extension, WebKitWebPage *web_page
 }
 
 G_MODULE_EXPORT void
-webkit_web_extension_initialize_with_user_data(WebKitWebExtension *extension, GVariant *user_data)
+webkit_web_process_extension_initialize_with_user_data(WebKitWebProcessExtension *extension, GVariant *user_data)
 {
   g_variant_ref(user_data);
-
   g_signal_connect(extension, "page-created", G_CALLBACK(web_page_created_callback), user_data);
   web_page_initialize(extension);
 }

--- a/src/lightdm-extension.c
+++ b/src/lightdm-extension.c
@@ -1,4 +1,4 @@
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 #include "extension/greeter_comm.h"
 #include "extension/greeter_config.h"
@@ -6,7 +6,7 @@
 #include "extension/lightdm.h"
 #include "extension/theme_utils.h"
 
-WebKitWebExtension *WebExtension;
+WebKitWebProcessExtension *WebExtension;
 extern guint64 page_id;
 
 static void
@@ -14,7 +14,7 @@ extension_initialize(
     WebKitScriptWorld *world,
     WebKitWebPage *web_page,
     WebKitFrame *web_frame,
-    WebKitWebExtension *extension)
+    WebKitWebProcessExtension *extension)
 {
   (void) web_page;
   (void) extension;
@@ -27,7 +27,7 @@ extension_initialize(
 }
 
 void
-web_page_initialize(WebKitWebExtension *extension)
+web_page_initialize(WebKitWebProcessExtension *extension)
 {
   WebExtension = extension;
   g_signal_connect(

--- a/src/lightdm-extension.h
+++ b/src/lightdm-extension.h
@@ -2,8 +2,8 @@
 #define LIGHTDM_EXTENSION_H 1
 
 #include <glib-object.h>
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
-void web_page_initialize(WebKitWebExtension *extension);
+void web_page_initialize(WebKitWebProcessExtension *extension);
 
 #endif

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,10 +1,6 @@
 #ifndef LOGGER_H
 #define LOGGER_H 1
 #include <glib.h>
-#include <locale.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
 #include <unistd.h>
 
 #define logger_raw(type, message, ...)                                                  \
@@ -20,17 +16,8 @@
     g_free(filename);                                                                   \
   }
 
-#define logger_debug(message, ...)              \
-  {                                             \
-    logger_raw("DEBUG", message, ##__VA_ARGS__) \
-  }
-#define logger_error(message, ...)              \
-  {                                             \
-    logger_raw("ERROR", message, ##__VA_ARGS__) \
-  }
-#define logger_warn(message, ...)              \
-  {                                            \
-    logger_raw("WARN", message, ##__VA_ARGS__) \
-  }
+#define logger_debug(message, ...) { logger_raw("DEBUG", message, ##__VA_ARGS__) }
+#define logger_error(message, ...) { logger_raw("ERROR", message, ##__VA_ARGS__) }
+#define logger_warn(message, ...) { logger_raw("WARN", message, ##__VA_ARGS__) }
 
 #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,25 +18,30 @@ web_extension_sources = [
   #'bridge/lightdm-signal.c',
 ]
 
-gtk3 = dependency('gtk+-3.0', version: '>=3.24')
-webkit2 = dependency('webkit2gtk-4.0', version: '>=2.34')
-webkit2_webext = dependency('webkit2gtk-web-extension-4.0', version: '>=2.34')
+# gtk3 = dependency('gtk+-3.0', version: '>=3.24')
+# webkit2 = dependency('webkit2gtk-4.0', version: '>=2.34')
+# webkit2_webext = dependency('webkit2gtk-web-extension-4.0', version: '>=2.34')
+gtk4 = dependency('gtk4', version: '>=4.18')
+webkit = dependency('webkitgtk-6.0', version: '>=2.48')
+webkit_webext = dependency('webkitgtk-web-process-extension-6.0', version: '>=2.48')
 
 yaml = dependency('yaml-0.1', version: '>=0.2')
-glib = dependency('glib-2.0', version: '>=2.68')
 lightdm = dependency('liblightdm-gobject-1')
 
 web_extension = library(
   'lightdm-sea-greeter-webext',
   web_extension_sources,
-  dependencies: [webkit2_webext, lightdm, yaml],
+  dependencies: [webkit_webext, lightdm, yaml],
   install: true,
-  install_dir: '/usr/lib/sea-greeter/'
+  install_dir: '/usr/lib/sea-greeter/',
 )
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(web_extension, description: 'webkit6-greeter-webext')
 
 greeter_sources = [
   'main.c',
-  'settings.c', 
+  'settings.c',
   'theme.c',
 
   'browser.c',
@@ -59,14 +64,13 @@ greeter_sources = [
 
 gnome = import('gnome')
 
-greeter_sources += gnome.compile_resources('sea_greeter-resources',
-  'sea-greeter.gresource.xml',
-  c_name: 'sea_greeter'
-)
+greeter_sources += gnome.compile_resources('sea_greeter-resources', 'sea-greeter.gresource.xml', c_name: 'sea_greeter')
 
 greeter = executable(
   'sea-greeter',
   greeter_sources,
-  dependencies: [webkit2, gtk3, yaml, glib, lightdm],
+  dependencies: [webkit, gtk4, yaml, lightdm],
   install: true,
 )
+
+test('basic', greeter)

--- a/src/theme.c
+++ b/src/theme.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 #include <yaml.h>
 
 #include "logger.h"
@@ -295,7 +295,7 @@ load_theme(Browser *browser)
 
   char *theme = NULL;
 
-  if (browser->is_primary) {
+  if (browser->is_valid) {
     theme = g_strdup(primary_html);
   } else {
     theme = g_strdup(secondary_html);

--- a/src/utils/ipc-main.c
+++ b/src/utils/ipc-main.c
@@ -1,11 +1,10 @@
 #include <gio/gio.h>
 #include <glib-object.h>
 #include <glib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <jsc/jsc.h>
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 #include "utils/utils.h"
 

--- a/src/utils/ipc-main.h
+++ b/src/utils/ipc-main.h
@@ -1,7 +1,7 @@
 #ifndef IPC_MAIN_H
 #define IPC_MAIN_H 1
 
-#include <webkit2/webkit2.h>
+#include <webkit/webkit.h>
 
 WebKitUserMessage *ipc_renderer_send_message_sync(WebKitWebView *web_view, WebKitUserMessage *message);
 void ipc_renderer_send_message(WebKitWebView *web_view, WebKitUserMessage *message, GAsyncReadyCallback callback);

--- a/src/utils/ipc-renderer.c
+++ b/src/utils/ipc-renderer.c
@@ -1,12 +1,10 @@
 #include <glib-object.h>
 #include <glib.h>
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 #include "utils/utils.h"
 

--- a/src/utils/ipc-renderer.h
+++ b/src/utils/ipc-renderer.h
@@ -1,7 +1,7 @@
 #ifndef IPC_RENDERER_H
 #define IPC_RENDERER_H 1
 
-#include <webkit2/webkit-web-extension.h>
+#include <webkit/webkit-web-process-extension.h>
 
 WebKitUserMessage *ipc_renderer_send_message_sync(WebKitWebPage *web_page, WebKitUserMessage *message);
 void ipc_renderer_send_message(WebKitWebPage *web_page, WebKitUserMessage *message, GAsyncReadyCallback callback);

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -1,6 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <glib.h>


### PR DESCRIPTION
This PR migrating sea-greeter from `gtk3` & `webkit2gtk` to `gtk4` & `webkitgtk-6.0`:

- Deprecated code has been removed.
- GTK4 & WebkitGTK-6.0 API changes have been adapted
- Removing some unused code.
- TODO: The `gtk_widget_destory` vfunc has gone, now using [`gtk_window_destory`](https://docs.gtk.org/gtk4/method.Window.destroy.html) instance method directly. But now, haven't found the place to invoke this destroy method yet.
- TODO: The `root_window` has gone, can not use it to set cursor anymore. Now, the cursor is set by [`gtk_widget_set_cursor_from_name`](https://docs.gtk.org/gtk4/method.Widget.set_cursor_from_name.html). This causes some bug, after right-click menu popup, the cursor shape changes to X shape, which means cursor setting does not take effect to popup menu. Right now, don't know how to fix this.